### PR TITLE
only <glib.h> can be included directly

### DIFF
--- a/headers/linux/include/libgnome/gnome-url.h
+++ b/headers/linux/include/libgnome/gnome-url.h
@@ -24,8 +24,10 @@
 #ifndef GNOME_URL_H
 #define GNOME_URL_H
 
-#include <glib/gmacros.h>
-#include <glib/gerror.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+#include <glib.h>
+//#include <glib/gmacros.h>
+//#include <glib/gerror.h>
 
 G_BEGIN_DECLS
 

--- a/headers/linux/include/libgnomevfs/gnome-vfs-async-ops.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-async-ops.h
@@ -25,7 +25,9 @@
 #ifndef GNOME_VFS_ASYNC_OPS_H
 #define GNOME_VFS_ASYNC_OPS_H
 
-#include <glib/giochannel.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+#include <glib.h>
+//#include <glib/giochannel.h>
 #include <libgnomevfs/gnome-vfs-file-info.h>
 #include <libgnomevfs/gnome-vfs-find-directory.h>
 #include <libgnomevfs/gnome-vfs-handle.h>

--- a/headers/linux/include/libgnomevfs/gnome-vfs-cancellation.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-cancellation.h
@@ -26,7 +26,9 @@
 #ifndef GNOME_VFS_CANCELLATION_H
 #define GNOME_VFS_CANCELLATION_H
 
-#include <glib/gtypes.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gtypes.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 

--- a/headers/linux/include/libgnomevfs/gnome-vfs-directory.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-directory.h
@@ -24,7 +24,9 @@
 #ifndef GNOME_VFS_DIRECTORY_H
 #define GNOME_VFS_DIRECTORY_H
 
-#include <glib/gmacros.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+#include <glib.h>
+//#include <glib/gmacros.h>
 #include <libgnomevfs/gnome-vfs-file-info.h>
 
 G_BEGIN_DECLS

--- a/headers/linux/include/libgnomevfs/gnome-vfs-file-size.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-file-size.h
@@ -26,7 +26,9 @@
 #ifndef GNOME_VFS_FILE_SIZE_H
 #define GNOME_VFS_FILE_SIZE_H
 
-#include <glib/gtypes.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+#include <glib.h>
+//#include <glib/gtypes.h>
 
 /*
  * This defines GnomeVFSFileSize and GnomeVFSFileOffset

--- a/headers/linux/include/libgnomevfs/gnome-vfs-init.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-init.h
@@ -24,7 +24,9 @@
 #ifndef GNOME_VFS_INIT_H
 #define GNOME_VFS_INIT_H
 
-#include <glib/gtypes.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gtypes.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 

--- a/headers/linux/include/libgnomevfs/gnome-vfs-mime-utils.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-mime-utils.h
@@ -24,7 +24,9 @@
 #ifndef GNOME_VFS_MIME_UTILS_H
 #define GNOME_VFS_MIME_UTILS_H
 
-#include <glib/gtypes.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gtypes.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 

--- a/headers/linux/include/libgnomevfs/gnome-vfs-result.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-result.h
@@ -26,7 +26,9 @@
 #ifndef GNOME_VFS_RESULT_H
 #define GNOME_VFS_RESULT_H
 
-#include <glib/gmacros.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gmacros.h>
+#include <glib.h>
 
 G_BEGIN_DECLS
 

--- a/headers/linux/include/libgnomevfs/gnome-vfs-standard-callbacks.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-standard-callbacks.h
@@ -26,7 +26,9 @@
 #ifndef GNOME_VFS_STANDARD_CALLBACKS_H
 #define GNOME_VFS_STANDARD_CALLBACKS_H
 
-#include <glib/gtypes.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gtypes.h>
+#include <glib.h>
 #include <libgnomevfs/gnome-vfs-uri.h>
 
 G_BEGIN_DECLS

--- a/headers/linux/include/libgnomevfs/gnome-vfs-uri.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-uri.h
@@ -24,7 +24,9 @@
 #ifndef GNOME_VFS_URI_H
 #define GNOME_VFS_URI_H
 
-#include <glib/glist.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+#include <glib.h>
+//#include <glib/glist.h>
 #include <glib-object.h> /* For GType */
 
 G_BEGIN_DECLS

--- a/headers/linux/include/libgnomevfs/gnome-vfs-utils.h
+++ b/headers/linux/include/libgnomevfs/gnome-vfs-utils.h
@@ -27,7 +27,9 @@
 #ifndef GNOME_VFS_UTILS_H
 #define GNOME_VFS_UTILS_H
 
-#include <glib/gmessages.h>
+// MDW 2013-06-05 : error: #error "Only <glib.h> can be included directly."
+//#include <glib/gmessages.h>
+#include <glib.h>
 #include <libgnomevfs/gnome-vfs-file-size.h>
 #include <libgnomevfs/gnome-vfs-result.h>
 #include <libgnomevfs/gnome-vfs-uri.h>


### PR DESCRIPTION
Fixes errors compiling on 64-bit linux mint. Errors with the gnome libraries resulting in "error: only <glib.h> can be included directly". Still compiles properly for me on 32-bit Fedora Core as well.
