### PR TITLE
64-bit defines for int64_t and uint64_t

### DIFF
--- a/libskia/include/config/sk_stdint.h
+++ b/libskia/include/config/sk_stdint.h
@@ -7,8 +7,14 @@ typedef short  int16_t;
 typedef unsigned short  uint16_t;
 typedef int  int32_t;
 typedef unsigned   uint32_t;
-typedef long long  int64_t;
-typedef unsigned long long   uint64_t;
+// MDW-2014-04-05: [[ x64 ]] check 64-bitness before defining
+#ifdef __LP64__
+	typedef long  int64_t;
+	typedef unsigned long   uint64_t;
+#else
+	typedef long long  int64_t;
+	typedef unsigned long long   uint64_t;
+#endif
 
 typedef int64_t   intmax_t;
 typedef uint64_t  uintmax_t;


### PR DESCRIPTION
I hate patching third-party libraries because of the technical debt incurred for making patches to future versions of the library, but this file has already been patched by Mark Waddingham a year ago, and this does solve the problem.

Without this patch, there's a conflict between two definitions of int64_t and uint64_t when building on a 64-bit linux system. This solves the conflict and allows the compilation to continue.
