### PR TITLE
openssl: Refactor stub library generation.

### DIFF
--- a/libmysql/libmysql.gyp
+++ b/libmysql/libmysql.gyp
@@ -24,7 +24,7 @@
 						
 						'dependencies':
 						[
-							'../libopenssl/libopenssl.gyp:libopenssl',
+							'../libopenssl/libopenssl.gyp:libopenssl_stubs',
 							'../libz/libz.gyp:libz',
 						],
 						

--- a/libopenssl/libopenssl.gyp
+++ b/libopenssl/libopenssl.gyp
@@ -8,8 +8,8 @@
 	[
 		{
 			'target_name': 'libopenssl_stubs',
-			'type': 'none',
-			
+			'type': 'static_library',
+
 			'variables':
 			{
 				'library_for_module': 1,
@@ -17,13 +17,13 @@
 			
 			'sources':
 			[
-				'ssl.stubs',
+				'<(INTERMEDIATE_DIR)/src/ssl.<(OS).stubs.cpp',
 			],
 			
 			'actions':
 			[
 				{
-					'action_name': 'libopenssl_stubs',
+					'action_name': 'generate_libopenssl_stubs',
 					'inputs':
 					[
 						'../../util/weak_stub_maker.pl',
@@ -31,9 +31,9 @@
 					],
 					'outputs':
 					[
-						'<(SHARED_INTERMEDIATE_DIR)/src/ssl.<(OS).stubs.cpp',
+						'<(INTERMEDIATE_DIR)/src/ssl.<(OS).stubs.cpp',
 					],
-					
+
 					'action':
 					[
 						'<@(perl)',
@@ -43,28 +43,7 @@
 					],
 				},
 			],
-		},
-		
-		{
-			'target_name': 'libopenssl',
-			'type': 'static_library',
-			
-			'variables':
-			{
-				'library_for_module': 1,
-			},
-			
-			'dependencies':
-			[
-				'libopenssl_stubs',
-				#'../../prebuilt/libopenssl.gyp:libopenssl',
-			],
-			
-			'sources':
-			[
-				'<(SHARED_INTERMEDIATE_DIR)/src/ssl.<(OS).stubs.cpp',
-			],
-			
+
 			'direct_dependent_settings':
 			{
 				'include_dirs':

--- a/libpq/libpq.gyp
+++ b/libpq/libpq.gyp
@@ -24,7 +24,7 @@
                         
 						'dependencies':
 						[
-							'../libopenssl/libopenssl.gyp:libopenssl',
+							'../libopenssl/libopenssl.gyp:libopenssl_stubs',
 						],
 						
 						'include_dirs':


### PR DESCRIPTION
Unify the generation of the openssl stub source file and
compilation of the stub library into one target.  This fixes a
problem when compiling with MS Visual Studio 2010 Express Edition
due to having two projects named "openssl" in the solution.
