### PR TITLE
Don't use LTO when building Android RevSecurity

### DIFF
--- a/libopenssl/libopenssl.gyp
+++ b/libopenssl/libopenssl.gyp
@@ -151,10 +151,15 @@
 								{
 									'product_name': 'RevSecurity',
 									'product_extension': '',
+
+									'ldflags!':
+									[
+										'-flto',
+									],
 								},
 							],
 						],
-						
+
 						'all_dependent_settings':
 						{
 							'variables':


### PR DESCRIPTION
There is some sort of impedance-mismatch that causes it to fail to link - this is probably due to the customcrypto and customssl static libraries being pre-builts.
