### PR TITLE
[Bug 15811][emscripten] Tweaks to libskia font support

### DIFF
--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -554,13 +554,20 @@
 					{
 						'sources!':
 						[
-							'src/ports/SkFontHost_fontconfig.cpp',
 							'src/ports/SkFontHost_FreeType.cpp',
 							'src/ports/SkFontHost_FreeType_common.cpp',
-                                                        'src/fonts/SkFontMgr_fontconfig.cpp',
-							
 							'src/sfnt/SkOTTable_name.cpp',
 							'src/sfnt/SkOTUtils.cpp',
+						],
+					},
+				],
+				[
+					'OS != "android"',
+					{
+						'sources!':
+						[
+							'src/ports/SkFontHost_fontconfig.cpp',
+                                                        'src/fonts/SkFontMgr_fontconfig.cpp',
 						],
 					},
 				],
@@ -569,7 +576,7 @@
                                         {
                                                 'defines':
                                                 [
-                                                       'SK_FONT_FILE_PREFIX="/boot/fonts/"',
+                                                       'SK_FONT_FILE_PREFIX="/boot/standalone/"',
                                                 ],
 
                                                 'dependencies':

--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -426,7 +426,6 @@
 				'src/ports/SkAtomics_win.h',
 				'src/ports/SkFontConfigParser_android.h',
 				'src/ports/SkFontConfigTypeface.h',
-				'src/ports/SkFontHost_FreeType_common.h',
 				'src/ports/SkMutex_none.h',
 				'src/ports/SkMutex_pthread.h',
 				'src/ports/SkMutex_win.h',

--- a/libskia/src/ports/SkFontHost_linux.cpp
+++ b/libskia/src/ports/SkFontHost_linux.cpp
@@ -379,6 +379,7 @@ private:
         static const char* gDefaultNames[] = {
             "Arial", "Verdana", "Times New Roman", NULL
         };
+        gDefaultNormal = NULL;
         for (size_t i = 0; i < SK_ARRAY_COUNT(gDefaultNames); ++i) {
             SkFontStyleSet_Custom* set = this->onMatchFamily(gDefaultNames[i]);
             if (NULL == set) {


### PR DESCRIPTION
Minor changes to libskia and libskia build to support multi-font support in the HTML5 engine.

N.b. the code that the HTML5 engine depends on has disappeared in newer versions of Skia, which should provide an interesting challenge.
