### PR TITLE
[Bug 17190] Ensure PCRE is built with NO_RECURSE

### DIFF
--- a/libpcre/ORIGIN
+++ b/libpcre/ORIGIN
@@ -2,5 +2,9 @@ Files in this folder are based on pcre-8.33 (previously pcre-6.7)
 
 Original source archives are available from <http://www.pcre.org/>
 
+Note that it is important that NO_RECURSE is defined in PCRE's
+config.h (via --disable-stack-for-recursion) in order to avoid a
+regression of bug 16.
+
 // TDZ-2013-09-09: [[ libpcre_8_33 ]]
 copy pcre-8.33/pcre.h.in  in libpcre/src/pcre.h

--- a/libpcre/src/config.h
+++ b/libpcre/src/config.h
@@ -227,7 +227,7 @@ sure both macros are undefined; an emulation function will then be used. */
    steam using pcre_recurse_malloc() to obtain memory from the heap. For more
    detail, see the comments and other stuff just above the match() function.
    */
-/* #undef NO_RECURSE */
+#define NO_RECURSE 1
 
 /* Name of package */
 #define PACKAGE "pcre"


### PR DESCRIPTION
By default, regular expression match recursion in PCRE is
performed on the stack, but this means that it's possible to run
out of stack with some combinations of regular expression and
target string.

Defining `NO_RECURSE` during PCRE compilation ensures that PCRE
recurses by allocating space on the heap rather than on the stack.  It
makes matching slower but ensures that regular expression matching is
only limited by the amount of RAM available in the system rather than
the amount of stack space available.
