### PR TITLE
cairo: Disable SSSE3-optimised code in pixman build

### DIFF
--- a/libcairo/libcairo.gyp
+++ b/libcairo/libcairo.gyp
@@ -427,7 +427,7 @@
 							'src/pixman-region32.c',
 							'src/pixman-solid-fill.c',
 							'src/pixman-sse2.c',
-							'src/pixman-ssse3.c',
+							#'src/pixman-ssse3.c',
 							'src/pixman-timer.c',
 							'src/pixman-trap.c',
 							'src/pixman-utils.c',


### PR DESCRIPTION
We don't actually enable the `USE_SSSE3` build so pixman's SSSE3
implementation was never used.  It's safe to just remove it from
the build.
