### PR TITLE
pixman: Don't undefine "sqrtf" macro

### DIFF
--- a/libcairo/src/pixman-config.h
+++ b/libcairo/src/pixman-config.h
@@ -180,6 +180,3 @@
 #ifndef __cplusplus
 #undef inline
 #endif
-
-/* Define to sqrt if you do not have the `sqrtf' function. */
-#undef sqrtf


### PR DESCRIPTION
On Windows, `sqrtf` is a macro.  The pixman configuration header will
incorrectly undefine the macro if the `sqrtf()` function exists, which
is... exceedingly unhelpful.

Upstream bug report/patch:
https://bugs.freedesktop.org/show_bug.cgi?id=97898
