### PR TITLE
Updates to allow ARMv7 builds of the Android engine

### DIFF
--- a/libffi/libffi.gyp
+++ b/libffi/libffi.gyp
@@ -127,10 +127,12 @@
 						{
 							'toolset_os': '<(host_os)',
 							'toolset_arch': '<(host_arch)',
+							'toolset_abi': '<(host_abi)',
 						},
 						{
 							'toolset_os': '<(OS)',
 							'toolset_arch': '<(target_arch)',
+							'toolset_abi': '<(target_abi)',
 						},
 					],
 				],
@@ -238,7 +240,7 @@
 					},
 				],
 				[
-					'(toolset_os == "linux" or toolset_os == "android") and (toolset_arch == "armv6" or toolset_arch == "armv6hf")',
+					'(toolset_os == "linux" or toolset_os == "android") and (toolset_arch == "armv6" or toolset_arch == "armv7a")',
 					{
 						'platform_include_dirs':
 						[
@@ -251,10 +253,19 @@
 							'<@(libffi_generic_sources)'
 						],
 						
-						# Disable VFP
-						'cflags':
+						# Disable VFP for ARMv6 Android builds (this is mis-
+						# detected by the libffi headers)
+						'conditions':
 						[
-							'-U__ARM_EABI__',
+							[
+								'toolset_os == "android" and toolset_arch == "armv6" and toolset_abi != "gnueabihf"',
+								{
+									'cflags':
+									[
+										'-U__ARM_EABI__',
+									],
+								}
+							],
 						],
 					},
 				],

--- a/libffi/src/arm/sysv.S
+++ b/libffi/src/arm/sysv.S
@@ -398,7 +398,7 @@ LSYM(Lbase_args):
 	beq	LSYM(Lepilogue_vfp)
 
 	cmp	r3, #FFI_TYPE_SINT64
-	stmeqia	r2, {r0, r1}
+	stmiaeq	r2, {r0, r1}
 	beq	LSYM(Lepilogue_vfp)
 
 	cmp	r3, #FFI_TYPE_FLOAT


### PR DESCRIPTION
Note that this depends on the changes in livecodefraser:config-triples as it adds support for passing OS ABI information to Gyp.

The second commit patches the libffi source code. This particular problem has already been fixed upstream but we have some issues with updating libffi that need to be looked into again.

Currently WIP pending the main branch changes and some testing.
