### PR TITLE
Update gyp source lists for PNG and JPEG header changes

### DIFF
--- a/libjpeg/libjpeg.gyp
+++ b/libjpeg/libjpeg.gyp
@@ -34,9 +34,7 @@
 							'include/jmorecfg.h',
 							'include/jpeglib.h',
 							
-							'src/jchuff.h',
 							'src/jdct.h',
-							'src/jdhuff.h',
 							'src/jinclude.h',
 							'src/jmemsys.h',
 							'src/jpegint.h',

--- a/libpng/libpng.gyp
+++ b/libpng/libpng.gyp
@@ -39,9 +39,9 @@
 							'include/pngdebug.h',
 							'include/pnginfo.h',
 							'include/pnglibconf.h',
-							'include/pngpriv.h',
 							'include/pngstruct.h',
 							
+							'src/pngpriv.h',
 							'src/png.c',
 							'src/pngerror.c',
 							'src/pngget.c',


### PR DESCRIPTION
- When libjpeg was updated in commit 4ef75b0cbc73, two headers were
  removed from the source tree but not from the gyp file
- When libpng was updated in commit 3de90c1ad358, a header was moved
  from its `include` directory to its `src` directory
