### PR TITLE
libxml: Fix compilation with C89 compiler

### DIFF
--- a/libxml/src/relaxng.c
+++ b/libxml/src/relaxng.c
@@ -2088,6 +2088,7 @@ xmlRelaxNGGetErrorString(xmlRelaxNGValidErr err, const xmlChar * arg1,
                          const xmlChar * arg2)
 {
     char msg[1000];
+	xmlChar *result = NULL;
 
     if (arg1 == NULL)
         arg1 = BAD_CAST "";
@@ -2215,7 +2216,7 @@ xmlRelaxNGGetErrorString(xmlRelaxNGValidErr err, const xmlChar * arg1,
         snprintf(msg, 1000, "Unknown error code %d\n", err);
     }
     msg[1000 - 1] = 0;
-    xmlChar *result = xmlCharStrdup(msg);
+    result = xmlCharStrdup(msg);
     return (xmlEscapeFormatString(&result));
 }
 

--- a/libxml/src/xmlschemas.c
+++ b/libxml/src/xmlschemas.c
@@ -3121,6 +3121,7 @@ xmlSchemaPSimpleTypeErr(xmlSchemaParserCtxtPtr ctxt,
 			const xmlChar *str2)
 {
     xmlChar *msg = NULL;
+	xmlChar *expectedEscaped = NULL;
 
     xmlSchemaFormatNodeForError(&msg, ACTXT_CAST ctxt, node);
     if (message == NULL) {
@@ -3169,7 +3170,7 @@ xmlSchemaPSimpleTypeErr(xmlSchemaParserCtxtPtr ctxt,
 	}
 	if (expected) {
 	    msg = xmlStrcat(msg, BAD_CAST " Expected is '");
-	    xmlChar *expectedEscaped = xmlCharStrdup(expected);
+	    expectedEscaped = xmlCharStrdup(expected);
 	    msg = xmlStrcat(msg, xmlEscapeFormatString(&expectedEscaped));
 	    FREE_AND_NULL(expectedEscaped);
 	    msg = xmlStrcat(msg, BAD_CAST "'.\n");


### PR DESCRIPTION
The MSVC 2010 C compiler only permits variable declarations
before the first statement in a function.
