### PR TITLE
libpcre: Ensure that PCRE_STATIC is defined everywhere it's needed

### DIFF
--- a/libpcre/libpcre.gyp
+++ b/libpcre/libpcre.gyp
@@ -67,6 +67,10 @@
 						
 						'direct_dependent_settings':
 						{
+							'defines':
+							[
+								'PCRE_STATIC=1',
+							],
 							'include_dirs':
 							[
 								'include',


### PR DESCRIPTION
This fixes a build failure on Windows introduced in commit a1c67345.
