### PR TITLE
[[ Bug 19213 ]] Update library names in CEF and SSL stubs

### DIFF
--- a/libcef/libcef.stubs
+++ b/libcef/libcef.stubs
@@ -1,4 +1,4 @@
-cef libcef.so libcef.dylib libcef.dll
+cef ./CEF/libcef ./CEF/libcef ./CEF/libcef
 	cef_add_cross_origin_whitelist_entry: (pointer,pointer,pointer,integer) -> (integer)
 	cef_add_web_plugin_directory: (pointer) -> ()
 	cef_add_web_plugin_path: (pointer) -> ()

--- a/libopenssl/libopenssl.gyp
+++ b/libopenssl/libopenssl.gyp
@@ -63,8 +63,18 @@
 				],
 			},
 		},
-	],
-	
+        
+        {
+            'target_name': 'revsecurity_built',
+            'type': 'none',
+
+            'dependencies':
+            [
+                'revsecurity',
+            ],
+        },
+    ],
+
 	'conditions':
 	[
 		[

--- a/libopenssl/ssl.stubs
+++ b/libopenssl/ssl.stubs
@@ -1,4 +1,4 @@
-crypto revsecurity.so revsecurity.dylib revsecurity.dll
+crypto ./revsecurity ./revsecurity ./revsecurity
 	OPENSSL_config: (pointer) -> ()
 	OPENSSL_init_crypto: (integer, pointer) -> (integer)
 
@@ -194,7 +194,7 @@ crypto revsecurity.so revsecurity.dylib revsecurity.dll
 	ENGINE_init: (pointer) -> (integer)
 	ENGINE_load_private_key: (pointer, pointer, pointer, pointer)-> (pointer)
 
-ssl revsecurity.so revsecurity.dylib revsecurity.dll
+ssl ./revsecurity ./revsecurity ./revsecurity
 
 	OPENSSL_init_ssl: (integer, pointer) -> (integer)
 


### PR DESCRIPTION
This patch ensures that the library name for revsecurity is
`./revsecurity` and the library name for libcef is `CEF/libcef`
allowing the weak stubs to use the new library loading API
correctly.