### PR TITLE
[Bug 19345] Load CEF from correct location on Linux & Win

### DIFF
--- a/libcef/libcef.stubs
+++ b/libcef/libcef.stubs
@@ -1,4 +1,4 @@
-cef ./CEF/libcef ./CEF/libcef ./CEF/libcef
+cef ./Externals/CEF/libcef ./CEF/libcef ./Externals/CEF/libcef
 	cef_add_cross_origin_whitelist_entry: (pointer,pointer,pointer,integer) -> (integer)
 	cef_add_web_plugin_directory: (pointer) -> ()
 	cef_add_web_plugin_path: (pointer) -> ()


### PR DESCRIPTION
When LiveCode is installed by the installer on Linux and Windows, the
CEF library is located in `./Externals/CEF`.  This patch updates the
CEF stubs file to attempt to load `libcef` from the correct location.
This comes at the cost of breaking using the browser widget and
revBrowser from a build tree, where the CEF library is located in
`./CEF` (see bug 19381).