### PR TITLE
[[ Skia Update ]] Fix emscripen builds

### DIFF
--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -1764,7 +1764,7 @@
 						'sources/':
 						[
 							# Disable windows-specific code
-							['exclude', '_win(_dw)?.cpp$'],
+							['exclude', '_win(_dw)?.*\\.cpp$'],
 							['exclude', '^src/.*/win/.*$'],
                             ['exclude', 'WIC\\.cpp$'],
 						],
@@ -1802,6 +1802,7 @@
 						[
 							# Disable anything CoreGraphics related
 							['exclude', 'CG\\.'],
+							['exclude', '_mac\\.cpp$'],
 						],
 					},
 				],
@@ -1872,8 +1873,8 @@
                             # Don't build FreeType or FontConfig code
                             ['exclude', 'fontconfig'],
                             ['exclude', 'FontConfig'],
-                            ['exclude', 'SkFontMgr_custom'],
-                        ],
+                            ['exclude', 'SkFontMgr_custom_(embedded|empty)'],	
+						],
                     },
                 ],
 				[


### PR DESCRIPTION
This patch fixes the missing font manager factory for emscripten due to a
change in skia. This patch also improves the exclusions of mac and
windows files as they were being included in emscripten also.