### PR TITLE
[[ Bug 19882 ]] Restrict SSE compiler flag scope in Skia

### DIFF
--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -243,7 +243,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[
@@ -297,7 +297,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[
@@ -351,7 +351,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[
@@ -406,7 +406,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[
@@ -460,7 +460,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[
@@ -514,7 +514,7 @@
 			'conditions':
 			[
 				[
-					'target_arch in ("i386", "x86", "x86_64", "i386 x86_64")',
+					'target_arch in ("i386", "x86", "x64", "x86_64", "i386 x86_64")',
 					{
 						'sources':
 						[

--- a/libskia/src/opts/opts_dummy.cpp
+++ b/libskia/src/opts/opts_dummy.cpp
@@ -1,0 +1,1 @@
+static int __dummy_unused__;


### PR DESCRIPTION
This patch ensures that only the files requiring specific compiler
flags are compiled with the specific compiler flags.

This fixes an issue where we were compiling Skia on Linux with
-msse4.2, meaning that the engine would not run on anything which
did not have SSE 4.2.