### PR TITLE
[[ Bug 20033 ]] Ensure SkOpts_crc32 file is included in ARM builds

### DIFF
--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -207,16 +207,9 @@
 					{
 						'sources':
 						[
-							'<@(opts_armv7_arm64_srcs)',
+                            '<@(opts_armv7_arm64_srcs)',
+                            '<@(opts_crc32_srcs)',
 						],
-					},
-					
-					'target_arch in ("arm64", "armv7 arm64")',
-					{
-						'sources':
-						[
-							'<@(opts_crc32_srcs)',
-						],					
 					},
 				],
 			],


### PR DESCRIPTION
This patch ensures that the SkOpts_crc32 file is included when building
for ARM.