### PR TITLE
[11919] Add support for URI filenames in SQLITE databases

### DIFF
--- a/libsqlite/include/sqlitedataset/dataset.h
+++ b/libsqlite/include/sqlitedataset/dataset.h
@@ -114,7 +114,7 @@ public:
   virtual const char *getErrorMsg(void) { return error.c_str(); }
   virtual void setErrDirect(const char *p_error) { error = p_error; }
 	
-  virtual int connect(void) { return DB_COMMAND_OK; }
+  virtual int connect(bool p_use_uri=false) { return DB_COMMAND_OK; }
   virtual int connectFull( const char *newDb, const char *newHost=NULL,
                       const char *newLogin=NULL, const char *newPasswd=NULL,const char *newPort=NULL);
   virtual void disconnect(void) { active = false; }

--- a/libsqlite/include/sqlitedataset/sqlitedataset.h
+++ b/libsqlite/include/sqlitedataset/sqlitedataset.h
@@ -64,7 +64,7 @@ public:
   virtual const char *getErrorMsg();
   
 /* func. connects to database-server */
-  virtual int connect();
+  virtual int connect(bool p_use_uri=false);
 /* func. disconnects from database-server */
   virtual void disconnect();
 /* func. creates new database */

--- a/libsqlite/libsqlite.gyp
+++ b/libsqlite/libsqlite.gyp
@@ -36,7 +36,6 @@
 							'SQLITE_ENABLE_FTS5',
 							'SQLITE_ENABLE_RTREE',
 							'SQLITE_ENABLE_JSON1',
-							'SQLITE_USE_URI',
 						],
 						
 						'sources':

--- a/libsqlite/libsqlite.gyp
+++ b/libsqlite/libsqlite.gyp
@@ -36,6 +36,7 @@
 							'SQLITE_ENABLE_FTS5',
 							'SQLITE_ENABLE_RTREE',
 							'SQLITE_ENABLE_JSON1',
+							'SQLITE_USE_URI',
 						],
 						
 						'sources':

--- a/libsqlite/src/sqlitedataset.cpp
+++ b/libsqlite/src/sqlitedataset.cpp
@@ -397,10 +397,14 @@ const char *SqliteDatabase::getErrorMsg() {
    return error.c_str();
 }
 
-int SqliteDatabase::connect()
+int SqliteDatabase::connect(bool p_use_uri)
 {
   disconnect();
-  int result = setErr(sqlite3_open(db.c_str(),&conn), NULL);
+  int result;
+  if (p_use_uri)
+    result = setErr(sqlite3_open_v2(db.c_str(),&conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI, 0), NULL);
+  else
+    result = setErr(sqlite3_open(db.c_str(),&conn), NULL);
   if (!result)
   {
     char* err=NULL;


### PR DESCRIPTION
Note: This needs an additional PR in the main livecode repo which will update the `revOpenDatabase` dictionary entry mentioning this new sqlite option (`uri`)