### PR TITLE
[[ Bug 21932 ]] Fix memory leak when executing sqlite queries

### DIFF
--- a/libsqlite/src/sqlitedataset.cpp
+++ b/libsqlite/src/sqlitedataset.cpp
@@ -737,6 +737,8 @@ static int sqlite3_query_exec(sqlite3 *db, const char *zSql, int (*xCallback)(vo
 			}
 		}
 
+        free(azVals);
+        azVals = 0;
 		free(azCols);
 		azCols = 0;
 	}


### PR DESCRIPTION
This patch fixes a memory leak when executing sqlite queries. The
leak is caused by failing to release the array holding the fetched
column values (azVals) in the sqlite3_query_exec function.