### PR TITLE
[[ Bug 22020 ]] Fix memory leak when dbsqlite connection fails

### DIFF
--- a/libsqlite/src/sqlitedataset.cpp
+++ b/libsqlite/src/sqlitedataset.cpp
@@ -426,7 +426,17 @@ int SqliteDatabase::connect(bool p_use_uri)
     return DB_CONNECTION_OK;
   }
   else
+  {
+      /* sqlite3_open will still create a connection object even if there is an
+       * error - unless it runs out of memory, in which case the connection
+       * pointer will be nullptr. */
+      if (conn != nullptr)
+      {
+          sqlite3_close(conn);
+          conn = nullptr;
+      }
 	  throw DbErrors(getErrorMsg());
+  }
 
   return DB_CONNECTION_NONE;
 };


### PR DESCRIPTION
This patch fixes a memory leak which occurs when opening a dbsqlite
connection fails. As sqlite3_open will create a connection struct
even if there is an error, sqlite3_close must be called regardless of
the error returned when opening it.