### PR TITLE
[[ RevPDFPrinter ]] Update thirdparty libs required by RevPDFPrinter on Android

### DIFF
--- a/libcairo/libcairo.gyp
+++ b/libcairo/libcairo.gyp
@@ -460,10 +460,24 @@
 						'conditions':
 						[
 							[
-								# Not supported on Android
-								'OS == "android" or OS == "emscripten"',
+								# Not supported on Emscripten
+								'OS == "emscripten"',
 								{
 									'type': 'none',
+								},
+							],
+							[
+								'OS == "android"',
+								{
+									'dependencies':
+									[
+										'../libfreetype/libfreetype.gyp:libfreetype',
+									],
+									# Use the FreeType support on Android
+									'sources/':
+									[
+										['include', '^src/cairo-ft.*\\.c$'],
+									],
 								},
 							],
 							[

--- a/libcairo/src/cairo-features.h
+++ b/libcairo/src/cairo-features.h
@@ -41,4 +41,10 @@
 #define CAIRO_HAS_FC_FONT 1
 #endif
 
+#ifdef TARGET_SUBPLATFORM_ANDROID
+#define CAIRO_NO_MUTEX 1
+#define HAVE_STDINT_H 1
+#define CAIRO_HAS_FT_FONT 1
+#endif
+
 #endif

--- a/libharfbuzz/libharfbuzz.gyp
+++ b/libharfbuzz/libharfbuzz.gyp
@@ -20,6 +20,7 @@
 			'dependencies':
 			[
 				'../../prebuilt/libicu.gyp:libicu_include',
+				'../libfreetype/libfreetype.gyp:libfreetype',
 			],
 			
 			'defines':
@@ -45,6 +46,7 @@
 				'src/hb-fallback-shape.cc',
 				'src/hb-face.cc',
 				'src/hb-font.cc',
+				'src/hb-ft.cc',
 				'src/hb-icu.cc',
 				'src/hb-ot-layout.cc',
 				'src/hb-ot-map.cc',

--- a/libskia/include/ports/SkTypeface_FreeType.h
+++ b/libskia/include/ports/SkTypeface_FreeType.h
@@ -1,0 +1,15 @@
+#ifndef SkTypeface_FreeType_DEFINED
+#define SkTypeface_FreeType_DEFINED
+
+#include "SkTypeface.h"
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+/**
+ * Obtain access to the underlying FT_Face of a SkTypeface.
+ * The FT_Face should be released with FT_Done_Face once finished.
+ **/
+SK_API extern FT_Face SkTypeface_GetFTFace(const SkTypeface* face);
+
+#endif  // SkTypeface_FreeType_DEFINED

--- a/libskia/src/ports/SkFontHost_FreeType.cpp
+++ b/libskia/src/ports/SkFontHost_FreeType.cpp
@@ -418,6 +418,20 @@ private:
 
 ///////////////////////////////////////////////////////////////////////////
 
+extern FT_Face SkTypeface_GetFTFace(const SkTypeface* face);
+FT_Face SkTypeface_GetFTFace(const SkTypeface* face)
+{
+	FT_Face t_face;
+	gFTMutex.acquire();
+	t_face = ref_ft_face(face);
+	FT_Reference_Face(t_face);
+	unref_ft_face(t_face);
+	gFTMutex.release();
+	return t_face;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
 static bool canEmbed(FT_Face face) {
     FT_UShort fsType = FT_Get_FSType_Flags(face);
     return (fsType & (FT_FSTYPE_RESTRICTED_LICENSE_EMBEDDING |


### PR DESCRIPTION
This patch makes several changes to thirdparty library builds required for the revPDFPrinter extension on Android:

* libcairo - enable Android build with libfreetype support
* libharfbuzz - add libfreetype support to Android build
* libskia - add accessor function to obtain FT_Face handle from SkTypeface object