### PR TITLE
[[ emscripten ]] Fix missing symbol errors when linking libskia for emscripten-wasm

### DIFF
--- a/libskia/libskia.gyp
+++ b/libskia/libskia.gyp
@@ -9,7 +9,6 @@
 		'skia_include_dirs':
 		[
 			'include/android',
-			'include/animator',
 			'include/c',
 			'include/codec',
 			'include/config',
@@ -27,7 +26,6 @@
 			'include/views',
 			'include/xml',
 			'src/android',
-			'src/animator',
 			'src/c',
 			'src/codec',
 			'src/core',
@@ -767,7 +765,7 @@
 				'src/animator/SkDisplayType.cpp',
 				'src/animator/SkDisplayTypes.cpp',
 				'src/animator/SkDisplayXMLParser.cpp',
-				'src/animator/SkDraw3D.h',
+				'src/animator/SkDraw3D.cpp',
 				'src/animator/SkDrawBitmap.cpp',
 				'src/animator/SkDrawBlur.cpp',
 				'src/animator/SkDrawClip.cpp',
@@ -799,7 +797,7 @@
 				'src/animator/SkMemberInfo.cpp',
 				'src/animator/SkOpArray.cpp',
 				'src/animator/SkOperandIterpolator.cpp',
-				'src/animator/SkPaintPart.h',
+				'src/animator/SkPaintPart.cpp',
 				'src/animator/SkParseSVGPath.cpp',
 				'src/animator/SkPathParts.cpp',
 				'src/animator/SkPostParts.cpp',
@@ -1146,7 +1144,7 @@
 				'src/core/SkLinearBitmapPipeline.cpp',
 				'src/core/SkLineClipper.cpp',
 				'src/core/SkLiteDL.cpp',
-				'src/core/SkLiteRecorder.h',
+				'src/core/SkLiteRecorder.cpp',
 				'src/core/SkLocalMatrixImageFilter.cpp',
 				'src/core/SkLocalMatrixShader.cpp',
 				'src/core/SkMallocPixelRef.cpp',
@@ -1722,11 +1720,8 @@
 				['exclude', '^src/codec/.*Codec.*\\.cpp$'],
 				['include', '^src/codec/SkCodec(ImageGenerator)?\\.cpp$'],
 				
-				# Disable animation scripting
-				['exclude', 'src/animator/SkScript'],
-				
-				# SkSnapshot doesn't build
-				['exclude', 'src/animator/SkSnapshot'],
+				# Disable unused and unsupported animator
+				['exclude', 'src/animator/*'],
 				
 				# Don't build XPS 
 				['exclude', '/xps/'],


### PR DESCRIPTION
This patch removes the source files under 'src/animator/*' from the libskia
build configuration as they are not used by the LiveCode engine and are no
longer maintained upstream.

This fixes a lot of missing symbol errors when linking libskia with the emscripten-wasm version of the standalone engine.