### PR TITLE
[[ Bug 21387 ]] Fix bug in Win32 stdcall closure trampoline

### DIFF
--- a/libffi/src/x86/win32.asm
+++ b/libffi/src/x86/win32.asm
@@ -1283,7 +1283,8 @@ ffi_closure_raw_SYSV ENDP
 
 
 ffi_closure_STDCALL PROC NEAR FORCEFRAME
-        mov  eax, [esp] ;; the ffi_closure ctx passed by the trampoline.
+		;; FORCEFRAME pushes onto the stack, so the ctx ptr is one word above
+        mov  eax, [esp + 4] ;; the ffi_closure ctx passed by the trampoline.
 
         sub  esp, 40
         lea  edx, [ebp - 24]


### PR DESCRIPTION
This patch fixes a bug in the Win32 specific closure trampoline
for the stdcall calling convention. Specifically, the `ffi_closure`
context pointer is now fetched from `esp + 4` rather than `esp`.
This is necessary as `FORCEFRAME` is used which pushes a register
onto the stack, meaning that the context pointer pushed by the
generated trampoline is one word higher up.