### PR TITLE
[[ Android ]] Fix crash on 32-bit Android devices when initializing OpenSSL

### DIFF
--- a/libopenssl/ssl.stubs
+++ b/libopenssl/ssl.stubs
@@ -1,7 +1,16 @@
 crypto ./revsecurity ./revsecurity ./revsecurity
-	OPENSSL_config: (pointer) -> ()
-	OPENSSL_init_crypto: (integer, pointer) -> (integer)
+	# OpenSSL 1.1.1g
 
+	# <openssl/conf.h>
+	OPENSSL_config: (pointer) -> ()
+
+	# <openssl/crypto.h>
+	OPENSSL_init_crypto: (integer64, pointer) -> (integer)
+
+	CRYPTO_malloc: (integer) -> (pointer)
+	CRYPTO_free: (pointer) -> ()
+
+	# <openssl/evp.h>
 	EVP_CipherInit: (pointer, pointer, pointer, pointer, integer) -> (integer)
 	EVP_CipherUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
 	EVP_CipherFinal: (pointer, pointer, pointer) -> (integer)
@@ -12,6 +21,33 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	EVP_PKEY_free: (pointer) -> ()
 	EVP_PKEY_get1_RSA: (pointer) -> (pointer)
 
+	EVP_rc4: () -> (pointer)
+	EVP_sha1: () -> (pointer)
+	EVP_add_digest: (pointer) -> (integer)
+	EVP_DigestInit: (pointer, pointer) -> (integer)
+	EVP_DigestUpdate: (pointer, pointer, integer) -> (integer)
+	EVP_DigestFinal: (pointer, pointer, pointer) -> (integer)
+	EVP_DecryptInit: (pointer, pointer, pointer, pointer) -> (integer)
+	EVP_DecryptUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
+	EVP_DecryptFinal: (pointer, pointer, pointer) -> (integer)
+
+	EVP_PKEY_new: () -> (pointer)
+	EVP_PKEY_assign: (pointer, integer, pointer) -> (pointer)
+	
+	EVP_CIPHER_key_length: (pointer) -> (integer)
+	EVP_CIPHER_CTX_new: () -> (pointer)
+	EVP_CIPHER_CTX_free: (pointer) -> ()
+	EVP_CIPHER_CTX_key_length: (pointer) -> (integer)
+	EVP_CIPHER_CTX_block_size: (pointer) -> (integer)
+	EVP_CIPHER_CTX_reset: (pointer) -> ()
+
+	EVP_MD_CTX_new: () -> (pointer)
+	EVP_MD_CTX_free: (pointer) -> ()
+
+	BIO_f_md: () -> (pointer)
+	BIO_f_base64: () -> (pointer)
+
+	# <openssl/error.h>
 	ERR_error_string: (integer, pointer) -> (pointer)
 	ERR_error_string_n: (integer, pointer, integer) -> ()
 	ERR_get_error: () -> (integer)
@@ -20,18 +56,14 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	ERR_reason_error_string: (integer) -> (pointer)
 	ERR_remove_state: (integer) -> ()
 
+	# <openssl/rand.h>
 	RAND_seed: (pointer, integer) -> ()
 	RAND_bytes: (pointer, integer) -> (integer)
 
-	X509_CRL_free: (pointer) -> ()
+	# <openssl/x509.h>
 	X509_EXTENSION_get_object: (pointer) -> (pointer)
 	X509_NAME_oneline: (pointer, pointer, integer) -> (pointer)
 	X509_NAME_get_text_by_NID: (pointer, integer, pointer, integer) -> (integer)
-	X509_STORE_add_cert: (pointer, pointer) -> (integer)
-	X509_STORE_add_crl: (pointer, pointer) -> (integer)
-	X509_STORE_CTX_get_error: (pointer) -> (integer)
-	X509_STORE_CTX_get_error_depth: (pointer) -> (integer)
-	X509_STORE_CTX_get_current_cert: (pointer) -> (pointer)
 	X509_verify_cert_error_string: (integer) -> (pointer)
 	X509_get_issuer_name: (pointer) -> (pointer)
 	X509_get_subject_name: (pointer) -> (pointer)
@@ -40,18 +72,37 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	X509_get_pubkey: (pointer) -> (pointer)
 	X509_get_ext: (pointer, integer) -> (pointer)
 	X509_check_private_key: (pointer, pointer) -> (integer)
+
 	X509_free: (pointer) -> ()
-    
+	X509_CRL_free: (pointer) -> ()
+	d2i_X509: (pointer, pointer, integer) -> (pointer)
+	i2d_X509: (pointer, pointer) -> (integer)
+	d2i_X509_bio: (pointer, pointer) -> (pointer)
+	d2i_X509_CRL: (pointer, pointer, integer) -> (pointer)
+	d2i_PUBKEY_bio: (pointer, pointer) -> (pointer)
+	d2i_PrivateKey_bio: (pointer, pointer) -> (pointer)
+
+	# <openssl/x509_vfy.h>
+	X509_STORE_add_cert: (pointer, pointer) -> (integer)
+	X509_STORE_add_crl: (pointer, pointer) -> (integer)
+	X509_STORE_CTX_get_error: (pointer) -> (integer)
+	X509_STORE_CTX_get_error_depth: (pointer) -> (integer)
+	X509_STORE_CTX_get_current_cert: (pointer) -> (pointer)
 	X509_STORE_load_locations: (pointer, pointer, pointer) -> (integer)
 	X509_STORE_set_flags: (pointer, integer) -> (integer)
 
+	# <openssl/x509v3.h>
 	X509V3_EXT_get: (pointer) -> (pointer)
 
+	GENERAL_NAMES_free: (pointer) -> ()
+
+	# <openssl/pem.h>
 	PEM_read_bio_X509_AUX: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_PUBKEY: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_RSAPublicKey: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_PrivateKey: (pointer, pointer, pointer, pointer) -> (pointer)
 
+	# <openssl/objects.h>
 	OBJ_obj2nid: (pointer) -> (integer)
 	OBJ_nid2sn: (pointer) -> (integer)
 	OBJ_nid2obj: (integer) -> (pointer)
@@ -60,6 +111,8 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	OBJ_create: (pointer, pointer, pointer) -> (integer)
 	? OBJ_NAME_do_all_sorted: (integer, pointer, pointer) -> ()
 
+	# <openssl/rsa.h>
+	RSA_new: () -> (pointer)
 	RSA_free: (pointer) -> ()
 	RSA_private_decrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
 	RSA_public_encrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
@@ -67,34 +120,28 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	RSA_public_decrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
 	RSA_size: (pointer) -> (integer)
 
-	d2i_X509: (pointer, pointer, integer) -> (pointer)
-	d2i_X509_bio: (pointer, pointer) -> (pointer)
-	
-	d2i_X509_CRL: (pointer, pointer, integer) -> (pointer)
+	RSA_set0_crt_params: (pointer, pointer, pointer, pointer) -> (integer)
+	RSA_set0_factors: (pointer, pointer, pointer) -> (integer)
+	RSA_set0_key: (pointer, pointer, pointer, pointer) -> (integer)
 
-	d2i_PUBKEY_bio: (pointer, pointer) -> (pointer)
-	
-	d2i_PrivateKey_bio: (pointer, pointer) -> (pointer)
-	
-	i2d_PKCS7: (pointer, pointer) -> (integer)
-	d2i_PKCS7: (pointer, pointer, integer) -> (pointer)
-	d2i_PKCS7_bio: (pointer, pointer) -> (pointer)
-	
-	i2d_PKCS7_SIGNER_INFO: (pointer, pointer) -> (integer)
-
-	i2d_X509: (pointer, pointer) -> (integer)
-	
+	# <openssl/pkcs7.h>
 	PKCS7_dataInit: (pointer, pointer) -> (pointer)
 	PKCS7_dataFinal: (pointer, pointer) -> (integer)
-	PKCS7_new: () -> (pointer)
 	PKCS7_content_new: (pointer, integer) -> (integer)
 	PKCS7_add_certificate: (pointer, pointer) -> (integer)
 	PKCS7_add_attribute: (pointer, integer, integer, pointer) -> (integer)
 	PKCS7_add_signed_attribute: (pointer, integer, integer, pointer) -> (integer)
 	PKCS7_add_signature: (pointer, pointer, pointer, pointer) -> (pointer)
 	PKCS7_set_type: (pointer, integer) -> (pointer)
-	PKCS7_free: (pointer) -> ()
 
+	PKCS7_new: () -> (pointer)
+	PKCS7_free: (pointer) -> ()
+	i2d_PKCS7: (pointer, pointer) -> (integer)
+	d2i_PKCS7: (pointer, pointer, integer) -> (pointer)
+	d2i_PKCS7_bio: (pointer, pointer) -> (pointer)
+	i2d_PKCS7_SIGNER_INFO: (pointer, pointer) -> (integer)
+
+	# <openssl/stack.h>
 	OPENSSL_sk_num: (pointer) -> (integer)
 	OPENSSL_sk_value: (pointer, integer) -> (pointer)
 	OPENSSL_sk_new: (pointer) -> (pointer)
@@ -102,6 +149,7 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	OPENSSL_sk_push: (pointer, pointer) -> (integer)
 	OPENSSL_sk_pop: (pointer) -> (pointer)
 	
+	# <openssl/bio.h>
 	BIO_new_file: (pointer, pointer) -> (pointer)
 	BIO_read: (pointer, pointer, integer) -> (integer)
 	BIO_write: (pointer, pointer, integer) -> (integer)
@@ -111,13 +159,9 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	BIO_free: (pointer) -> (integer)
 	BIO_new_mem_buf: (pointer, integer) -> (pointer)
 	BIO_ctrl: (pointer, integer, integer, pointer) -> (integer)
-	BIO_f_md: () -> (pointer)
-	BIO_f_base64: () -> (pointer)
 	BIO_free_all: (pointer) -> (integer)
-	
-	CRYPTO_malloc: (integer) -> (pointer)
-	CRYPTO_free: (pointer) -> ()
-	
+
+	# <openssl/ans1.h>
 	ASN1_item_d2i: (pointer, pointer, integer, pointer) -> (pointer)
 	ASN1_item_i2d: (pointer, pointer, pointer) -> (integer)
 	ASN1_item_new: (pointer) -> (pointer)
@@ -150,45 +194,18 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	ASN1_OBJECT_it: () -> (pointer)
 	ASN1_NULL_it: () -> (pointer)
 	
+	# <openssl/bn.h>
 	BN_new: () -> (pointer)
 	BN_free: (pointer) -> ()
 	BN_set_word: (pointer, integer) -> (integer)
 	BN_bin2bn: (pointer, integer, pointer) -> (pointer)
 	
+	# <openssl/dh.h>
 	DH_free: (pointer) -> ()
 	DH_new: () -> (pointer)
 	DH_set0_pqg: (pointer, pointer, pointer, pointer) -> (integer)
 
-	EVP_rc4: () -> (pointer)
-	EVP_sha1: () -> (pointer)
-	EVP_add_digest: (pointer) -> (integer)
-	EVP_DigestInit: (pointer, pointer) -> (integer)
-	EVP_DigestUpdate: (pointer, pointer, integer) -> (integer)
-	EVP_DigestFinal: (pointer, pointer, pointer) -> (integer)
-	EVP_DecryptInit: (pointer, pointer, pointer, pointer) -> (integer)
-	EVP_DecryptUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
-	EVP_DecryptFinal: (pointer, pointer, pointer) -> (integer)
-	
-	EVP_PKEY_new: () -> (pointer)
-	EVP_PKEY_assign: (pointer, integer, pointer) -> (pointer)
-	
-	EVP_CIPHER_key_length: (pointer) -> (integer)
-	EVP_CIPHER_CTX_new: () -> (pointer)
-	EVP_CIPHER_CTX_free: (pointer) -> ()
-	EVP_CIPHER_CTX_key_length: (pointer) -> (integer)
-	EVP_CIPHER_CTX_block_size: (pointer) -> (integer)
-	EVP_CIPHER_CTX_reset: (pointer) -> ()
-
-	EVP_MD_CTX_new: () -> (pointer)
-	EVP_MD_CTX_free: (pointer) -> ()
-	
-	RSA_new: () -> (pointer)
-	RSA_set0_crt_params: (pointer, pointer, pointer, pointer) -> (integer)
-	RSA_set0_factors: (pointer, pointer, pointer) -> (integer)
-	RSA_set0_key: (pointer, pointer, pointer, pointer) -> (integer)
-	
-	GENERAL_NAMES_free: (pointer) -> ()
-
+	# <openssl/engine.h>
 	ENGINE_by_id: (pointer) -> (pointer)
 	ENGINE_finish: (pointer) -> (integer)
 	ENGINE_free: (pointer) -> (integer)
@@ -197,7 +214,8 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 
 ssl ./revsecurity ./revsecurity ./revsecurity
 
-	OPENSSL_init_ssl: (integer, pointer) -> (integer)
+	# <openssl/ssl.h>
+	OPENSSL_init_ssl: (integer64, pointer) -> (integer)
 
 	SSL_new: (pointer) -> (pointer)
 	SSL_free: (pointer) -> ()
@@ -213,38 +231,14 @@ ssl ./revsecurity ./revsecurity ./revsecurity
 	SSL_set_accept_state: (pointer) -> ()
 	SSL_get_peer_certificate: (pointer) -> (pointer)
 	SSL_get_verify_result: (pointer) -> (integer)
-
 	SSL_get_peer_cert_chain: (pointer) -> (pointer)
-
-	SSL_CTX_set_default_verify_paths: (pointer) -> (integer)
-	SSL_CTX_load_verify_locations: (pointer, pointer, pointer) -> (integer)
-	SSL_CTX_set_verify: (pointer, integer, pointer) -> ()
-	SSL_CTX_set_verify_depth: (pointer, integer) -> ()
-	SSL_CTX_new: (pointer) -> (pointer)
-	SSL_CTX_free: (pointer) -> ()
-	SSL_CTX_get_cert_store: (pointer) -> (pointer)
-	
-	TLS_method: () -> (pointer)
-
-	TLSv1_client_method: () -> (pointer)
-	TLSv1_server_method: () -> (pointer)
-	SSL_CIPHER_get_name: (pointer) -> (pointer)
-	SSL_CTX_check_private_key: (pointer) -> (integer)
-	SSL_CTX_ctrl: (pointer, integer, integer, pointer) -> (integer)
-	SSL_CTX_set_cipher_list: (pointer, pointer) -> (integer)
-	SSL_CTX_set_session_id_context: (pointer, pointer, integer) -> (integer)
-	SSL_CTX_use_certificate_file: (pointer, pointer, integer) -> (integer)
-	SSL_CTX_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
-	SSL_SESSION_set_timeout: (pointer, integer) -> (integer)
 	SSL_get_current_cipher: (pointer) -> (pointer)
 	SSL_get_fd: (pointer) -> (integer)
 	SSL_get_session: (pointer) -> (pointer)
 	SSL_get_shared_ciphers: (pointer, pointer, integer) -> (pointer)
 	SSL_pending: (pointer) -> (integer)
 	SSL_set_quiet_shutdown: (pointer, integer) -> ()
-	SSL_CTX_set_options: (pointer, integer) -> (integer)
 	SSL_set_options: (pointer, integer) -> (integer)
-	SSL_CTX_use_certificate_chain_file: (pointer, pointer) -> (integer)
 	SSL_check_private_key: (pointer) -> (integer)
 	SSL_ctrl: (pointer, integer, integer, pointer) -> (integer)
 	SSL_set_ex_data: (pointer, integer, pointer) -> (integer)
@@ -252,3 +246,27 @@ ssl ./revsecurity ./revsecurity ./revsecurity
 	SSL_use_PrivateKey: (pointer, pointer) -> (integer)
 	SSL_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
 	SSL_use_certificate_file: (pointer, pointer, integer) -> (integer)
+
+	SSL_CTX_new: (pointer) -> (pointer)
+	SSL_CTX_free: (pointer) -> ()
+	SSL_CTX_set_default_verify_paths: (pointer) -> (integer)
+	SSL_CTX_load_verify_locations: (pointer, pointer, pointer) -> (integer)
+	SSL_CTX_set_verify: (pointer, integer, pointer) -> ()
+	SSL_CTX_set_verify_depth: (pointer, integer) -> ()
+	SSL_CTX_get_cert_store: (pointer) -> (pointer)
+	SSL_CTX_check_private_key: (pointer) -> (integer)
+	SSL_CTX_ctrl: (pointer, integer, integer, pointer) -> (integer)
+	SSL_CTX_set_cipher_list: (pointer, pointer) -> (integer)
+	SSL_CTX_set_session_id_context: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_set_options: (pointer, integer) -> (integer)
+	SSL_CTX_use_certificate_file: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_use_certificate_chain_file: (pointer, pointer) -> (integer)
+	
+	SSL_CIPHER_get_name: (pointer) -> (pointer)
+	SSL_SESSION_set_timeout: (pointer, integer) -> (integer)
+
+	TLS_method: () -> (pointer)
+
+	TLSv1_client_method: () -> (pointer)
+	TLSv1_server_method: () -> (pointer)

--- a/libopenssl/ssl_ios.stubs
+++ b/libopenssl/ssl_ios.stubs
@@ -1,7 +1,16 @@
 crypto ./revsecurity ./revsecurity ./revsecurity
-	OPENSSL_config: (pointer) -> ()
-	OPENSSL_init_crypto: (integer, pointer) -> (integer)
+	# OpenSSL 1.1.1g
 
+	# <openssl/conf.h>
+	OPENSSL_config: (pointer) -> ()
+
+	# <openssl/crypto.h>
+	OPENSSL_init_crypto: (integer64, pointer) -> (integer)
+
+	CRYPTO_malloc: (integer) -> (pointer)
+	CRYPTO_free: (pointer) -> ()
+
+	# <openssl/evp.h>
 	EVP_CipherInit: (pointer, pointer, pointer, pointer, integer) -> (integer)
 	EVP_CipherUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
 	EVP_CipherFinal: (pointer, pointer, pointer) -> (integer)
@@ -12,6 +21,33 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	EVP_PKEY_free: (pointer) -> ()
 	EVP_PKEY_get1_RSA: (pointer) -> (pointer)
 
+	EVP_rc4: () -> (pointer)
+	EVP_sha1: () -> (pointer)
+	EVP_add_digest: (pointer) -> (integer)
+	EVP_DigestInit: (pointer, pointer) -> (integer)
+	EVP_DigestUpdate: (pointer, pointer, integer) -> (integer)
+	EVP_DigestFinal: (pointer, pointer, pointer) -> (integer)
+	EVP_DecryptInit: (pointer, pointer, pointer, pointer) -> (integer)
+	EVP_DecryptUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
+	EVP_DecryptFinal: (pointer, pointer, pointer) -> (integer)
+
+	EVP_PKEY_new: () -> (pointer)
+	EVP_PKEY_assign: (pointer, integer, pointer) -> (pointer)
+	
+	EVP_CIPHER_key_length: (pointer) -> (integer)
+	EVP_CIPHER_CTX_new: () -> (pointer)
+	EVP_CIPHER_CTX_free: (pointer) -> ()
+	EVP_CIPHER_CTX_key_length: (pointer) -> (integer)
+	EVP_CIPHER_CTX_block_size: (pointer) -> (integer)
+	EVP_CIPHER_CTX_reset: (pointer) -> ()
+
+	EVP_MD_CTX_new: () -> (pointer)
+	EVP_MD_CTX_free: (pointer) -> ()
+
+	BIO_f_md: () -> (pointer)
+	BIO_f_base64: () -> (pointer)
+
+	# <openssl/error.h>
 	ERR_error_string: (integer, pointer) -> (pointer)
 	ERR_error_string_n: (integer, pointer, integer) -> ()
 	ERR_get_error: () -> (integer)
@@ -20,18 +56,14 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	ERR_reason_error_string: (integer) -> (pointer)
 	ERR_remove_state: (integer) -> ()
 
+	# <openssl/rand.h>
 	RAND_seed: (pointer, integer) -> ()
 	RAND_bytes: (pointer, integer) -> (integer)
 
-	X509_CRL_free: (pointer) -> ()
+	# <openssl/x509.h>
 	X509_EXTENSION_get_object: (pointer) -> (pointer)
 	X509_NAME_oneline: (pointer, pointer, integer) -> (pointer)
 	X509_NAME_get_text_by_NID: (pointer, integer, pointer, integer) -> (integer)
-	X509_STORE_add_cert: (pointer, pointer) -> (integer)
-	X509_STORE_add_crl: (pointer, pointer) -> (integer)
-	X509_STORE_CTX_get_error: (pointer) -> (integer)
-	X509_STORE_CTX_get_error_depth: (pointer) -> (integer)
-	X509_STORE_CTX_get_current_cert: (pointer) -> (pointer)
 	X509_verify_cert_error_string: (integer) -> (pointer)
 	X509_get_issuer_name: (pointer) -> (pointer)
 	X509_get_subject_name: (pointer) -> (pointer)
@@ -40,18 +72,37 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	X509_get_pubkey: (pointer) -> (pointer)
 	X509_get_ext: (pointer, integer) -> (pointer)
 	X509_check_private_key: (pointer, pointer) -> (integer)
+
 	X509_free: (pointer) -> ()
-    
+	X509_CRL_free: (pointer) -> ()
+	d2i_X509: (pointer, pointer, integer) -> (pointer)
+	i2d_X509: (pointer, pointer) -> (integer)
+	d2i_X509_bio: (pointer, pointer) -> (pointer)
+	d2i_X509_CRL: (pointer, pointer, integer) -> (pointer)
+	d2i_PUBKEY_bio: (pointer, pointer) -> (pointer)
+	d2i_PrivateKey_bio: (pointer, pointer) -> (pointer)
+
+	# <openssl/x509_vfy.h>
+	X509_STORE_add_cert: (pointer, pointer) -> (integer)
+	X509_STORE_add_crl: (pointer, pointer) -> (integer)
+	X509_STORE_CTX_get_error: (pointer) -> (integer)
+	X509_STORE_CTX_get_error_depth: (pointer) -> (integer)
+	X509_STORE_CTX_get_current_cert: (pointer) -> (pointer)
 	X509_STORE_load_locations: (pointer, pointer, pointer) -> (integer)
 	X509_STORE_set_flags: (pointer, integer) -> (integer)
 
+	# <openssl/x509v3.h>
 	X509V3_EXT_get: (pointer) -> (pointer)
 
+	GENERAL_NAMES_free: (pointer) -> ()
+
+	# <openssl/pem.h>
 	PEM_read_bio_X509_AUX: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_PUBKEY: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_RSAPublicKey: (pointer, pointer, pointer, pointer) -> (pointer)
 	PEM_read_bio_PrivateKey: (pointer, pointer, pointer, pointer) -> (pointer)
 
+	# <openssl/objects.h>
 	OBJ_obj2nid: (pointer) -> (integer)
 	OBJ_nid2sn: (pointer) -> (integer)
 	OBJ_nid2obj: (integer) -> (pointer)
@@ -60,6 +111,8 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	OBJ_create: (pointer, pointer, pointer) -> (integer)
 	? OBJ_NAME_do_all_sorted: (integer, pointer, pointer) -> ()
 
+	# <openssl/rsa.h>
+	RSA_new: () -> (pointer)
 	RSA_free: (pointer) -> ()
 	RSA_private_decrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
 	RSA_public_encrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
@@ -67,34 +120,28 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	RSA_public_decrypt: (integer, pointer, pointer, pointer, integer) -> (integer)
 	RSA_size: (pointer) -> (integer)
 
-	d2i_X509: (pointer, pointer, integer) -> (pointer)
-	d2i_X509_bio: (pointer, pointer) -> (pointer)
-	
-	d2i_X509_CRL: (pointer, pointer, integer) -> (pointer)
+	RSA_set0_crt_params: (pointer, pointer, pointer, pointer) -> (integer)
+	RSA_set0_factors: (pointer, pointer, pointer) -> (integer)
+	RSA_set0_key: (pointer, pointer, pointer, pointer) -> (integer)
 
-	d2i_PUBKEY_bio: (pointer, pointer) -> (pointer)
-	
-	d2i_PrivateKey_bio: (pointer, pointer) -> (pointer)
-	
-	i2d_PKCS7: (pointer, pointer) -> (integer)
-	d2i_PKCS7: (pointer, pointer, integer) -> (pointer)
-	d2i_PKCS7_bio: (pointer, pointer) -> (pointer)
-	
-	i2d_PKCS7_SIGNER_INFO: (pointer, pointer) -> (integer)
-
-	i2d_X509: (pointer, pointer) -> (integer)
-	
+	# <openssl/pkcs7.h>
 	PKCS7_dataInit: (pointer, pointer) -> (pointer)
 	PKCS7_dataFinal: (pointer, pointer) -> (integer)
-	PKCS7_new: () -> (pointer)
 	PKCS7_content_new: (pointer, integer) -> (integer)
 	PKCS7_add_certificate: (pointer, pointer) -> (integer)
 	PKCS7_add_attribute: (pointer, integer, integer, pointer) -> (integer)
 	PKCS7_add_signed_attribute: (pointer, integer, integer, pointer) -> (integer)
 	PKCS7_add_signature: (pointer, pointer, pointer, pointer) -> (pointer)
 	PKCS7_set_type: (pointer, integer) -> (pointer)
-	PKCS7_free: (pointer) -> ()
 
+	PKCS7_new: () -> (pointer)
+	PKCS7_free: (pointer) -> ()
+	i2d_PKCS7: (pointer, pointer) -> (integer)
+	d2i_PKCS7: (pointer, pointer, integer) -> (pointer)
+	d2i_PKCS7_bio: (pointer, pointer) -> (pointer)
+	i2d_PKCS7_SIGNER_INFO: (pointer, pointer) -> (integer)
+
+	# <openssl/stack.h>
 	OPENSSL_sk_num: (pointer) -> (integer)
 	OPENSSL_sk_value: (pointer, integer) -> (pointer)
 	OPENSSL_sk_new: (pointer) -> (pointer)
@@ -102,6 +149,7 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	OPENSSL_sk_push: (pointer, pointer) -> (integer)
 	OPENSSL_sk_pop: (pointer) -> (pointer)
 	
+	# <openssl/bio.h>
 	BIO_new_file: (pointer, pointer) -> (pointer)
 	BIO_read: (pointer, pointer, integer) -> (integer)
 	BIO_write: (pointer, pointer, integer) -> (integer)
@@ -111,13 +159,9 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	BIO_free: (pointer) -> (integer)
 	BIO_new_mem_buf: (pointer, integer) -> (pointer)
 	BIO_ctrl: (pointer, integer, integer, pointer) -> (integer)
-	BIO_f_md: () -> (pointer)
-	BIO_f_base64: () -> (pointer)
 	BIO_free_all: (pointer) -> (integer)
-	
-	CRYPTO_malloc: (integer) -> (pointer)
-	CRYPTO_free: (pointer) -> ()
-	
+
+	# <openssl/ans1.h>
 	ASN1_item_d2i: (pointer, pointer, integer, pointer) -> (pointer)
 	ASN1_item_i2d: (pointer, pointer, pointer) -> (integer)
 	ASN1_item_new: (pointer) -> (pointer)
@@ -150,48 +194,21 @@ crypto ./revsecurity ./revsecurity ./revsecurity
 	ASN1_OBJECT_it: () -> (pointer)
 	ASN1_NULL_it: () -> (pointer)
 	
+	# <openssl/bn.h>
 	BN_new: () -> (pointer)
 	BN_free: (pointer) -> ()
 	BN_set_word: (pointer, integer) -> (integer)
 	BN_bin2bn: (pointer, integer, pointer) -> (pointer)
 	
+	# <openssl/dh.h>
 	DH_free: (pointer) -> ()
 	DH_new: () -> (pointer)
 	DH_set0_pqg: (pointer, pointer, pointer, pointer) -> (integer)
 
-	EVP_rc4: () -> (pointer)
-	EVP_sha1: () -> (pointer)
-	EVP_add_digest: (pointer) -> (integer)
-	EVP_DigestInit: (pointer, pointer) -> (integer)
-	EVP_DigestUpdate: (pointer, pointer, integer) -> (integer)
-	EVP_DigestFinal: (pointer, pointer, pointer) -> (integer)
-	EVP_DecryptInit: (pointer, pointer, pointer, pointer) -> (integer)
-	EVP_DecryptUpdate: (pointer, pointer, pointer, pointer, integer) -> (integer)
-	EVP_DecryptFinal: (pointer, pointer, pointer) -> (integer)
-	
-	EVP_PKEY_new: () -> (pointer)
-	EVP_PKEY_assign: (pointer, integer, pointer) -> (pointer)
-	
-	EVP_CIPHER_key_length: (pointer) -> (integer)
-	EVP_CIPHER_CTX_new: () -> (pointer)
-	EVP_CIPHER_CTX_free: (pointer) -> ()
-	EVP_CIPHER_CTX_key_length: (pointer) -> (integer)
-	EVP_CIPHER_CTX_block_size: (pointer) -> (integer)
-	EVP_CIPHER_CTX_reset: (pointer) -> ()
-
-	EVP_MD_CTX_new: () -> (pointer)
-	EVP_MD_CTX_free: (pointer) -> ()
-	
-	RSA_new: () -> (pointer)
-	RSA_set0_crt_params: (pointer, pointer, pointer, pointer) -> (integer)
-	RSA_set0_factors: (pointer, pointer, pointer) -> (integer)
-	RSA_set0_key: (pointer, pointer, pointer, pointer) -> (integer)
-	
-	GENERAL_NAMES_free: (pointer) -> ()
-
 ssl ./revsecurity ./revsecurity ./revsecurity
 
-	OPENSSL_init_ssl: (integer, pointer) -> (integer)
+	# <openssl/ssl.h>
+	OPENSSL_init_ssl: (integer64, pointer) -> (integer)
 
 	SSL_new: (pointer) -> (pointer)
 	SSL_free: (pointer) -> ()
@@ -207,38 +224,14 @@ ssl ./revsecurity ./revsecurity ./revsecurity
 	SSL_set_accept_state: (pointer) -> ()
 	SSL_get_peer_certificate: (pointer) -> (pointer)
 	SSL_get_verify_result: (pointer) -> (integer)
-
 	SSL_get_peer_cert_chain: (pointer) -> (pointer)
-
-	SSL_CTX_set_default_verify_paths: (pointer) -> (integer)
-	SSL_CTX_load_verify_locations: (pointer, pointer, pointer) -> (integer)
-	SSL_CTX_set_verify: (pointer, integer, pointer) -> ()
-	SSL_CTX_set_verify_depth: (pointer, integer) -> ()
-	SSL_CTX_new: (pointer) -> (pointer)
-	SSL_CTX_free: (pointer) -> ()
-	SSL_CTX_get_cert_store: (pointer) -> (pointer)
-	
-	TLS_method: () -> (pointer)
-
-	TLSv1_client_method: () -> (pointer)
-	TLSv1_server_method: () -> (pointer)
-	SSL_CIPHER_get_name: (pointer) -> (pointer)
-	SSL_CTX_check_private_key: (pointer) -> (integer)
-	SSL_CTX_ctrl: (pointer, integer, integer, pointer) -> (integer)
-	SSL_CTX_set_cipher_list: (pointer, pointer) -> (integer)
-	SSL_CTX_set_session_id_context: (pointer, pointer, integer) -> (integer)
-	SSL_CTX_use_certificate_file: (pointer, pointer, integer) -> (integer)
-	SSL_CTX_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
-	SSL_SESSION_set_timeout: (pointer, integer) -> (integer)
 	SSL_get_current_cipher: (pointer) -> (pointer)
 	SSL_get_fd: (pointer) -> (integer)
 	SSL_get_session: (pointer) -> (pointer)
 	SSL_get_shared_ciphers: (pointer, pointer, integer) -> (pointer)
 	SSL_pending: (pointer) -> (integer)
 	SSL_set_quiet_shutdown: (pointer, integer) -> ()
-	SSL_CTX_set_options: (pointer, integer) -> (integer)
 	SSL_set_options: (pointer, integer) -> (integer)
-	SSL_CTX_use_certificate_chain_file: (pointer, pointer) -> (integer)
 	SSL_check_private_key: (pointer) -> (integer)
 	SSL_ctrl: (pointer, integer, integer, pointer) -> (integer)
 	SSL_set_ex_data: (pointer, integer, pointer) -> (integer)
@@ -246,3 +239,27 @@ ssl ./revsecurity ./revsecurity ./revsecurity
 	SSL_use_PrivateKey: (pointer, pointer) -> (integer)
 	SSL_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
 	SSL_use_certificate_file: (pointer, pointer, integer) -> (integer)
+
+	SSL_CTX_new: (pointer) -> (pointer)
+	SSL_CTX_free: (pointer) -> ()
+	SSL_CTX_set_default_verify_paths: (pointer) -> (integer)
+	SSL_CTX_load_verify_locations: (pointer, pointer, pointer) -> (integer)
+	SSL_CTX_set_verify: (pointer, integer, pointer) -> ()
+	SSL_CTX_set_verify_depth: (pointer, integer) -> ()
+	SSL_CTX_get_cert_store: (pointer) -> (pointer)
+	SSL_CTX_check_private_key: (pointer) -> (integer)
+	SSL_CTX_ctrl: (pointer, integer, integer, pointer) -> (integer)
+	SSL_CTX_set_cipher_list: (pointer, pointer) -> (integer)
+	SSL_CTX_set_session_id_context: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_set_options: (pointer, integer) -> (integer)
+	SSL_CTX_use_certificate_file: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_use_PrivateKey_file: (pointer, pointer, integer) -> (integer)
+	SSL_CTX_use_certificate_chain_file: (pointer, pointer) -> (integer)
+	
+	SSL_CIPHER_get_name: (pointer) -> (pointer)
+	SSL_SESSION_set_timeout: (pointer, integer) -> (integer)
+
+	TLS_method: () -> (pointer)
+
+	TLSv1_client_method: () -> (pointer)
+	TLSv1_server_method: () -> (pointer)


### PR DESCRIPTION
This patch fixes a crash on 32-bit Android devices when calling the function OPENSSL_init_ssl, due to the change of signature from versions 1.1.0g to 1.1.1g (int param changed to uint64_t param)

I've also grouped the stub declarations by the openssl headers in which the function is declared